### PR TITLE
fix: use workflow_run pattern for perf comments on fork PRs

### DIFF
--- a/.github/workflows/comment-perf.yml
+++ b/.github/workflows/comment-perf.yml
@@ -1,0 +1,51 @@
+name: Post perf comparison comment
+
+on:
+  workflow_run:
+    workflows: ["Basic Tests"]
+    types: [completed]
+
+jobs:
+  comment:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download perf data
+        uses: actions/download-artifact@v7
+        with:
+          name: perf-comment
+          path: ${{ runner.temp }}/perf_tests/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout base repo
+        uses: actions/checkout@v6
+        with:
+          ref: master
+      - uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          run-install: false
+          post-cleanup: false
+      - name: Apply workarounds
+        run: |
+          sed -i.bak 's@editable = true@editable = false@g' pyproject.toml
+          rm pyproject.toml.bak
+      - name: Render comparison
+        run: |
+          pixi run -e py314 display-benchmark-comparison \
+            --test-results-dir ${{ runner.temp }}/perf_tests/ \
+            --md-output ${{ runner.temp }}/perf_tests/pretty.md
+      - name: Post comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "" ]; then
+            echo "No PR number found, skipping"
+            exit 0
+          fi
+          gh pr comment "$PR_NUMBER" --body-file ${{ runner.temp }}/perf_tests/pretty.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Download math result for job 1
         uses: actions/download-artifact@v7
@@ -127,14 +126,12 @@ jobs:
       - name: Compare tests
         run: |
           pixi run -e py314 display-benchmark-comparison --test-results-dir ${{ runner.temp }}/perf_tests/ --md-output ${{ runner.temp }}/perf_tests/pretty.md
-      - name: Create Comment
+      - name: Upload perf comparison data
         if: ${{ github.event_name == 'pull_request' }}
-        run:
-          gh pr comment $PRNUM --body-file ${{ runner.temp }}/perf_tests/pretty.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PRNUM: ${{ github.event.pull_request.number }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-comment
+          path: ${{ runner.temp }}/perf_tests/
 
   # run-profiling:
   #   name: Profile presigned URLs


### PR DESCRIPTION
## Summary

- Fix "Resource not accessible by integration" error when posting perf comparison comments on fork PRs
- Split comment posting into a separate trusted `workflow_run` workflow (`comment-perf.yml`) that has write permissions
- The untrusted `pull_request` workflow now only uploads benchmark JSON as an artifact
- The trusted workflow checks out `master` from the base repo (never fork code), renders the markdown, and posts the comment