### PR TITLE
feat: add delete bucket method in client

### DIFF
--- a/benchmark_tests/conftest.py
+++ b/benchmark_tests/conftest.py
@@ -44,7 +44,7 @@ def rustfs_server():
         "9000:9000",
         "-p",
         "9001:9001",
-        "rustfs/rustfs:latest",
+        "rustfs/rustfs:1.0.0-beta.3",
         "/data",
     ]
     subprocess.run(cmd, check=True)  # noqa: S603

--- a/src/signurlarity/_base.py
+++ b/src/signurlarity/_base.py
@@ -803,3 +803,71 @@ class _BaseClient:
                 result["Errors"] = errors
 
         return result
+
+    def _prepare_delete_bucket(
+        self, Bucket: str, **kwargs
+    ) -> tuple[str, dict[str, str]]:
+        """Validate and build a signed DELETE bucket request.
+
+        Args:
+            Bucket: S3 bucket name
+            **kwargs: Additional arguments (e.g., ExpectedBucketOwner)
+
+        Returns:
+            Tuple of (url, signed_headers)
+
+        """
+        if not Bucket:
+            raise PresignError("Missing required parameter 'Bucket'")
+
+        base_url, path, headers = self._build_request_url(Bucket)
+
+        query_params = {}
+        if "ExpectedBucketOwner" in kwargs:
+            query_params["expected-bucket-owner"] = kwargs["ExpectedBucketOwner"]
+
+        signed_headers = self._presigner.sign_request_headers(
+            method="DELETE",
+            path=path,
+            headers=headers,
+        )
+
+        url = base_url + path
+        if query_params:
+            url = f"{url}?{self._build_query_string(query_params)}"
+
+        return url, signed_headers
+
+    def _parse_delete_bucket_response(
+        self,
+        response: httpx.Response,
+        Bucket: str,
+    ) -> dict[str, Any]:
+        """Parse delete bucket response, raising on errors."""
+        if response.status_code == 404:
+            raise NoSuchBucketError(
+                f"Bucket '{Bucket}' does not exist or is not accessible"
+            )
+        elif response.status_code == 409:
+            raise PresignError(f"Bucket '{Bucket}' is not empty.")
+        elif response.status_code == 403:
+            raise PresignError(
+                f"Access denied to bucket '{Bucket}'. Check credentials and permissions."
+            )
+        elif response.status_code == 400:
+            raise PresignError(
+                f"Bad request for delete_bucket '{Bucket}': {response.text}"
+            )
+        elif response.status_code not in (200, 204):
+            raise PresignError(
+                f"DELETE request failed with status {response.status_code}: {response.text}"
+            )
+
+        result: dict[str, Any] = {
+            "ResponseMetadata": {
+                "HTTPStatusCode": response.status_code,
+                "HTTPHeaders": dict(response.headers),
+            },
+        }
+
+        return result

--- a/src/signurlarity/aio/client.py
+++ b/src/signurlarity/aio/client.py
@@ -560,3 +560,31 @@ class AsyncClient(_BaseClient):
         )
         response = await self._execute_request("POST", url, signed_headers, body)
         return self._parse_delete_objects_response(response, Bucket)
+
+    async def delete_bucket(self, Bucket: str, **kwargs) -> dict[str, Any]:
+        """Delete an S3 bucket.
+
+        Performs a DELETE request to remove the bucket.
+
+        Args:
+            Bucket: S3 bucket name (required)
+            **kwargs: Additional arguments (ExpectedBucketOwner, etc.)
+
+        Returns:
+            dict with response metadata containing:
+                - ResponseMetadata: Response metadata with HTTPStatusCode and HTTPHeaders
+
+        Raises:
+            NoSuchBucketError: If bucket does not exist or is not accessible
+            PresignError: If request signing or execution fails
+
+        Reference:
+            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_bucket.html
+
+        Example:
+            >>> response = await client.delete_bucket(Bucket="mybucket")
+
+        """
+        url, signed_headers = self._prepare_delete_bucket(Bucket, **kwargs)
+        response = await self._execute_request("DELETE", url, signed_headers)
+        return self._parse_delete_bucket_response(response, Bucket)

--- a/src/signurlarity/client.py
+++ b/src/signurlarity/client.py
@@ -545,3 +545,31 @@ class Client(_BaseClient):
         )
         response = self._execute_request("POST", url, signed_headers, body)
         return self._parse_delete_objects_response(response, Bucket)
+
+    def delete_bucket(self, Bucket: str, **kwargs) -> dict[str, Any]:
+        """Delete an S3 bucket.
+
+        Performs a DELETE request to remove the bucket.
+
+        Args:
+            Bucket: S3 bucket name (required)
+            **kwargs: Additional arguments (ExpectedBucketOwner, etc.)
+
+        Returns:
+            dict with response metadata containing:
+                - ResponseMetadata: Response metadata with HTTPStatusCode and HTTPHeaders
+
+        Raises:
+            NoSuchBucketError: If bucket does not exist or is not accessible
+            PresignError: If request signing or execution fails
+
+        Reference:
+            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_bucket.html
+
+        Example:
+            >>> response = client.delete_bucket(Bucket="mybucket")
+
+        """
+        url, signed_headers = self._prepare_delete_bucket(Bucket, **kwargs)
+        response = self._execute_request("DELETE", url, signed_headers)
+        return self._parse_delete_bucket_response(response, Bucket)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,6 +224,8 @@ def seaweedfs_server():
             f"{tmp_dir}/seaweedfs",
             "-s3.config",
             f"{tmp_dir}/seaweedfs_s3.json",
+            # explicitely disable deleting non empty bucket
+            "-s3.allowDeleteBucketNotEmpty=false",
         ]
         with open(f"{tmp_dir}/seaweedfs.log", "w") as log_file:
             pid = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -542,9 +542,10 @@ def test_delete_bucket(s3_clients):
     boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
 
     # Delete objects before deleting bucket
+    objects = light_client.list_objects(Bucket=BUCKET_NAME)
     light_client.delete_objects(
         Bucket=BUCKET_NAME,
-        Delete={"Objects": [{"Key": key}]},
+        Delete={"Objects": [{"Key": obj["Key"]} for obj in objects["Contents"]]},
     )
 
     # Delete bucket using our async client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -530,6 +530,56 @@ def test_delete_objects_missing_objects(s3_clients):
         )
 
 
+def test_delete_bucket(s3_clients):
+    """Test that delete_bucket correctly deleted."""
+    boto_client, light_client = s3_clients
+
+    # Create some objects using boto
+    key = "delete-test-1.txt"
+    boto_client.put_object(Body=b"test content", Bucket=BUCKET_NAME, Key=key)
+
+    # Verify objects exist
+    boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
+
+    # Delete objects before deleting bucket
+    light_client.delete_objects(
+        Bucket=BUCKET_NAME,
+        Delete={"Objects": [{"Key": key}]},
+    )
+
+    # Delete bucket using our async client
+    response = light_client.delete_bucket(Bucket=BUCKET_NAME)
+    assert "ResponseMetadata" in response
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 204
+    assert "Contents" not in response
+
+
+def test_delete_bucket_missing_bucket(s3_clients):
+    """Test that delete_bucket raises PresignError for missing Bucket."""
+    _boto_client, light_client = s3_clients
+    from signurlarity.exceptions import PresignError
+
+    with pytest.raises(PresignError):
+        light_client.delete_bucket(Bucket="")
+
+
+def test_delete_bucket_not_empty(s3_clients):
+    """Test that delete_bucket raises PresignError if Bucket is not empty."""
+    boto_client, light_client = s3_clients
+    from signurlarity.exceptions import PresignError
+
+    # Create some objects using boto
+    key = "delete-test-1.txt"
+    boto_client.put_object(Body=b"test content", Bucket=BUCKET_NAME, Key=key)
+
+    # Verify objects exist
+    boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
+
+    # Try to delete non empty bucket
+    with pytest.raises(PresignError):
+        light_client.delete_bucket(Bucket=BUCKET_NAME)
+
+
 # @pytest.fixture()
 # def fix_1():
 #     print("entering fix 1")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -533,23 +533,25 @@ def test_delete_objects_missing_objects(s3_clients):
 def test_delete_bucket(s3_clients):
     """Test that delete_bucket correctly deleted."""
     boto_client, light_client = s3_clients
+    bucket_name = "test-bucket-to-delete"
 
+    boto_client.create_bucket(Bucket=bucket_name)
     # Create some objects using boto
     key = "delete-test-1.txt"
-    boto_client.put_object(Body=b"test content", Bucket=BUCKET_NAME, Key=key)
+    boto_client.put_object(Body=b"test content", Bucket=bucket_name, Key=key)
 
     # Verify objects exist
-    boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
+    boto_client.head_object(Bucket=bucket_name, Key=key)
 
     # Delete objects before deleting bucket
-    objects = light_client.list_objects(Bucket=BUCKET_NAME)
+    objects = light_client.list_objects(Bucket=bucket_name)
     light_client.delete_objects(
-        Bucket=BUCKET_NAME,
+        Bucket=bucket_name,
         Delete={"Objects": [{"Key": obj["Key"]} for obj in objects["Contents"]]},
     )
 
     # Delete bucket using our async client
-    response = light_client.delete_bucket(Bucket=BUCKET_NAME)
+    response = light_client.delete_bucket(Bucket=bucket_name)
     assert "ResponseMetadata" in response
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 204
     assert "Contents" not in response

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -584,9 +584,10 @@ async def test_delete_bucket_aio(s3_clients_aio):
     await boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
 
     # Delete objects before deleting bucket
+    objects = await async_light_client.list_objects(Bucket=BUCKET_NAME)
     await async_light_client.delete_objects(
         Bucket=BUCKET_NAME,
-        Delete={"Objects": [{"Key": key}]},
+        Delete={"Objects": [{"Key": obj["Key"]} for obj in objects["Contents"]]},
     )
 
     # Delete bucket using our async client

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -569,3 +569,56 @@ async def test_delete_objects_missing_objects_aio(s3_clients_aio):
             Bucket=BUCKET_NAME,
             Delete={"Objects": []},
         )
+
+
+@pytest.mark.asyncio
+async def test_delete_bucket_aio(s3_clients_aio):
+    """Test that delete_bucket correctly deleted."""
+    boto_client, async_light_client = s3_clients_aio
+
+    # Create some objects using boto
+    key = "delete-test-1.txt"
+    await boto_client.put_object(Body=b"test content", Bucket=BUCKET_NAME, Key=key)
+
+    # Verify objects exist
+    await boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
+
+    # Delete objects before deleting bucket
+    await async_light_client.delete_objects(
+        Bucket=BUCKET_NAME,
+        Delete={"Objects": [{"Key": key}]},
+    )
+
+    # Delete bucket using our async client
+    response = await async_light_client.delete_bucket(Bucket=BUCKET_NAME)
+    assert "ResponseMetadata" in response
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 204
+    assert "Contents" not in response
+
+
+@pytest.mark.asyncio
+async def test_delete_bucket_missing_bucket_aio(s3_clients_aio):
+    """Test that delete_bucket raises PresignError for missing Bucket (async)."""
+    _boto_client, async_light_client = s3_clients_aio
+    from signurlarity.exceptions import PresignError
+
+    with pytest.raises(PresignError):
+        await async_light_client.delete_bucket(Bucket="")
+
+
+@pytest.mark.asyncio
+async def test_delete_bucket_not_empty_aio(s3_clients_aio):
+    """Test that delete_bucket raises PresignError if Bucket is not empty (async)."""
+    boto_client, async_light_client = s3_clients_aio
+    from signurlarity.exceptions import PresignError
+
+    # Create some objects using boto
+    key = "delete-test-1.txt"
+    await boto_client.put_object(Body=b"test content", Bucket=BUCKET_NAME, Key=key)
+
+    # Verify objects exist
+    await boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
+
+    # Try to delete non empty bucket
+    with pytest.raises(PresignError):
+        await async_light_client.delete_bucket(Bucket=BUCKET_NAME)

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -575,23 +575,25 @@ async def test_delete_objects_missing_objects_aio(s3_clients_aio):
 async def test_delete_bucket_aio(s3_clients_aio):
     """Test that delete_bucket correctly deleted."""
     boto_client, async_light_client = s3_clients_aio
+    bucket_name = "test-bucket-to-delete-aio"
 
+    await boto_client.create_bucket(Bucket=bucket_name)
     # Create some objects using boto
     key = "delete-test-1.txt"
-    await boto_client.put_object(Body=b"test content", Bucket=BUCKET_NAME, Key=key)
+    await boto_client.put_object(Body=b"test content", Bucket=bucket_name, Key=key)
 
     # Verify objects exist
-    await boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
+    await boto_client.head_object(Bucket=bucket_name, Key=key)
 
     # Delete objects before deleting bucket
-    objects = await async_light_client.list_objects(Bucket=BUCKET_NAME)
-    await async_light_client.delete_objects(
-        Bucket=BUCKET_NAME,
-        Delete={"Objects": [{"Key": obj["Key"]} for obj in objects["Contents"]]},
-    )
-
+    objects = await async_light_client.list_objects(Bucket=bucket_name)
+    if objects.get("Contents"):
+        await async_light_client.delete_objects(
+            Bucket=bucket_name,
+            Delete={"Objects": [{"Key": obj["Key"]} for obj in objects["Contents"]]},
+        )
     # Delete bucket using our async client
-    response = await async_light_client.delete_bucket(Bucket=BUCKET_NAME)
+    response = await async_light_client.delete_bucket(Bucket=bucket_name)
     assert "ResponseMetadata" in response
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 204
     assert "Contents" not in response


### PR DESCRIPTION
When dropping boto dependency (c.f. https://github.com/DIRACGrid/diracx/pull/901) in diracx I noticed that `delete_bucket` method was not implemented but used in diracx tests.

Related to https://github.com/DIRACGrid/diracx/issues/712

- in `_baseClient` add a `_prepare` and `_parse` methods for `delete_bucket`
- in client and async client add the public `delete_bucket` method
- write unit tests for both

Note: some parts are based on IA generated code.