### PR TITLE
fix: percent-encode object keys in header-signed request paths

### DIFF
--- a/src/signurlarity/_base.py
+++ b/src/signurlarity/_base.py
@@ -100,7 +100,7 @@ class _BaseClient:
             # For custom endpoints, use path-style URLs
             actual_host = parsed.netloc
             if key:
-                path = f"/{bucket}/{key}"
+                path = f"/{bucket}/{self._presigner._uri_encode_path(key)}"
             else:
                 path = f"/{bucket}"
             base_url = f"{scheme}://{actual_host}"
@@ -108,7 +108,7 @@ class _BaseClient:
         else:
             # For AWS endpoints, use virtual-hosted style
             actual_host = self._presigner._get_host(bucket)
-            path = f"/{key}" if key else "/"
+            path = f"/{self._presigner._uri_encode_path(key)}" if key else "/"
             base_url = f"{scheme}://{actual_host}"
             headers = {"host": actual_host}
 

--- a/src/signurlarity/presigner.py
+++ b/src/signurlarity/presigner.py
@@ -296,7 +296,13 @@ class S3Presigner:
 
         Args:
             method: HTTP method (GET, HEAD, PUT, POST, DELETE, etc.)
-            path: Request path relative to host (e.g., '/' for bucket, '/key' for object)
+            path: URL-encoded request path relative to host, exactly as it will
+                appear on the wire (e.g., '/' for bucket, '/key' for object). The
+                path is used verbatim as the canonical URI, so any characters that
+                require percent-encoding (':', spaces, '+', etc.) must already be
+                encoded by the caller (see ``_uri_encode_path``). Passing a raw,
+                unencoded key produces a canonical URI that mismatches what a
+                signature-validating backend computes, yielding SignatureDoesNotMatch.
             headers: Request headers dict (must include 'host')
             timestamp: Optional fixed timestamp for testing. Default: current UTC time
             body: Request body bytes. Default: empty bytes

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -75,6 +75,39 @@ def test_head_object_exists(s3_clients):
     assert response["ContentType"] == "text/plain"
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        "diracAdmin/admin/admin/sha256:abc123.tar.zst",  # the real-world trigger
+        "with space/file.txt",
+        "plus+sign/file.txt",
+    ],
+)
+def test_head_object_special_chars(s3_clients, key):
+    """head_object must work for keys with chars that require percent-encoding.
+
+    A signature-validating backend (minio, rustfs) percent-encodes the request
+    path per the SigV4 spec before recomputing the signature, so the canonical
+    URI we sign must be encoded the same way. Keys containing ':', spaces or '+'
+    previously produced a SignatureDoesNotMatch -> 403.
+    """
+    boto_client, light_client = s3_clients
+
+    file_content = b"test content for special-char head_object"
+    boto_client.put_object(
+        Body=file_content, Bucket=BUCKET_NAME, Key=key, ContentType="text/plain"
+    )
+
+    # Sanity: the key is legal on the backend.
+    boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
+
+    response = light_client.head_object(Bucket=BUCKET_NAME, Key=key)
+
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["ContentLength"] == len(file_content)
+    assert response["ContentType"] == "text/plain"
+
+
 def test_head_object_not_found(s3_clients):
     """Test that head_object raises PresignError for non-existent object."""
     _boto_client, light_client = s3_clients

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -93,6 +93,40 @@ async def test_head_object_exists_aio(s3_clients_aio):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key",
+    [
+        "diracAdmin/admin/admin/sha256:abc123.tar.zst",  # the real-world trigger
+        "with space/file.txt",
+        "plus+sign/file.txt",
+    ],
+)
+async def test_head_object_special_chars_aio(s3_clients_aio, key):
+    """head_object must work for keys with chars that require percent-encoding.
+
+    A signature-validating backend (minio, rustfs) percent-encodes the request
+    path per the SigV4 spec before recomputing the signature, so the canonical
+    URI we sign must be encoded the same way. Keys containing ':', spaces or '+'
+    previously produced a SignatureDoesNotMatch -> 403.
+    """
+    boto_client, async_light_client = s3_clients_aio
+
+    file_content = b"test content for special-char head_object"
+    await boto_client.put_object(
+        Body=file_content, Bucket=BUCKET_NAME, Key=key, ContentType="text/plain"
+    )
+
+    # Sanity: the key is legal on the backend.
+    await boto_client.head_object(Bucket=BUCKET_NAME, Key=key)
+
+    response = await async_light_client.head_object(Bucket=BUCKET_NAME, Key=key)
+
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["ContentLength"] == len(file_content)
+    assert response["ContentType"] == "text/plain"
+
+
+@pytest.mark.asyncio
 async def test_head_object_not_found_aio(s3_clients_aio):
     """Test that head_object raises PresignError for non-existent object."""
     _boto_client, async_light_client = s3_clients_aio

--- a/tests/test_presigner.py
+++ b/tests/test_presigner.py
@@ -1,0 +1,75 @@
+"""Unit tests for request-path encoding (no live backend / Docker required).
+
+These lock the SigV4 canonical-URI encoding so a regression is caught in CI even
+when no signature-validating backend (minio/rustfs) is available. The signed
+canonical URI and the wire URL are both built from the single ``path`` returned
+by ``_build_request_url``; if that path is not percent-encoded the same way a
+backend re-encodes it, head_object fails with SignatureDoesNotMatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from signurlarity import Client
+
+from .conftest import BUCKET_NAME
+
+ENDPOINT_URL = "http://localhost:9999"
+
+
+@pytest.fixture()
+def client():
+    """Return a Client pointed at a non-existent endpoint (no request is made)."""
+    c = Client(
+        endpoint_url=ENDPOINT_URL,
+        aws_access_key_id="x",
+        aws_secret_access_key="y",  # noqa: S106
+    )
+    yield c
+    c.close()
+
+
+def test_build_request_url_encodes_special_chars(client):
+    """Percent-encode chars that require it, keeping bucket and slashes intact."""
+    key = "p/sha256:abc def+ghi"
+    _base_url, path, _headers = client._build_request_url(BUCKET_NAME, key)
+
+    # Bucket and the path separators are preserved.
+    assert path == f"/{BUCKET_NAME}/p/sha256%3Aabc%20def%2Bghi"
+
+    # No raw special characters survive in the path.
+    assert ":" not in path
+    assert " " not in path
+    assert "+" not in path
+
+
+def test_build_request_url_no_key_is_unchanged(client):
+    """Bucket-only requests need no encoding."""
+    _base_url, path, _headers = client._build_request_url(BUCKET_NAME)
+    assert path == f"/{BUCKET_NAME}"
+
+
+def test_build_request_url_simple_key_unchanged(client):
+    """Keys with only unreserved chars are unaffected (encoded == raw)."""
+    _base_url, path, _headers = client._build_request_url(BUCKET_NAME, "a/b/file.txt")
+    assert path == f"/{BUCKET_NAME}/a/b/file.txt"
+
+
+def test_header_and_presigned_paths_encode_identically(client):
+    """The two signing paths must encode keys the same way so they cannot drift.
+
+    ``generate_presigned_url`` (download path) and ``_build_request_url``
+    (header-signed path) both feed the canonical URI, so the encoded key segment
+    must appear identically in each.
+    """
+    key = "p/sha256:abc def+ghi"
+    encoded_key = "p/sha256%3Aabc%20def%2Bghi"
+
+    _base_url, path, _headers = client._build_request_url(BUCKET_NAME, key)
+    presigned_url = client._presigner.generate_presigned_url(
+        bucket=BUCKET_NAME, key=key
+    )
+
+    assert encoded_key in path
+    assert encoded_key in presigned_url


### PR DESCRIPTION
`head_object` raised a spurious 403 ("Access denied ... Check credentials and permissions") for keys containing characters that AWS SigV4 requires to be percent-encoded, such as the ':' in sandbox keys like `diracAdmin/admin/admin/sha256:24946....`

The header-signing path built the canonical URI and wire URL from the raw key, while `generate_presigned_url` already encoded it. A signature-validating backend (minio, rustfs, real S3) re-encodes the received path per the spec before recomputing the signature, so the raw colon yielded a mismatching signature and a 403.

Encode the key once in `_build_request_url` (sync + async), mirroring `generate_presigned_url`, so the single encoded path feeds both the signed canonical URI and the wire URL and they agree by construction.