### PR TITLE
fix: raise NoSuchKeyError on 404 for object operations

### DIFF
--- a/src/signurlarity/_base.py
+++ b/src/signurlarity/_base.py
@@ -15,6 +15,7 @@ from .exceptions import (
     BucketAlreadyExistsError,
     BucketAlreadyOwnedByYouError,
     NoSuchBucketError,
+    NoSuchKeyError,
     PresignError,
 )
 from .presigner import S3Presigner
@@ -304,7 +305,7 @@ class _BaseClient:
     ) -> dict[str, Any]:
         """Parse HEAD object response, raising on errors."""
         if response.status_code == 404:
-            raise PresignError(
+            raise NoSuchKeyError(
                 f"Object '{Key}' in bucket '{Bucket}' does not exist or is not accessible"
             )
         elif response.status_code == 403:
@@ -466,7 +467,7 @@ class _BaseClient:
     ) -> dict[str, Any]:
         """Parse copy-object response, raising on errors."""
         if response.status_code == 404:
-            raise PresignError(
+            raise NoSuchKeyError(
                 f"Source or destination not found for copy to '{Bucket}/{Key}'"
             )
         elif response.status_code == 403:
@@ -664,7 +665,9 @@ class _BaseClient:
     ) -> dict[str, Any]:
         """Parse PUT object response, raising on errors."""
         if response.status_code == 404:
-            raise PresignError(f"Bucket '{Bucket}' does not exist or is not accessible")
+            raise NoSuchBucketError(
+                f"Bucket '{Bucket}' does not exist or is not accessible"
+            )
         elif response.status_code == 403:
             raise PresignError(
                 f"Access denied to bucket '{Bucket}'. Check credentials and permissions."

--- a/src/signurlarity/aio/client.py
+++ b/src/signurlarity/aio/client.py
@@ -294,7 +294,7 @@ class AsyncClient(_BaseClient):
                 - ResponseMetadata: Response metadata with HTTPStatusCode and HTTPHeaders
 
         Raises:
-            NoSuchBucketError: If bucket does not exist
+            NoSuchKeyError: If the object does not exist
             PresignError: If request signing or execution fails
 
         Reference:
@@ -414,6 +414,7 @@ class AsyncClient(_BaseClient):
                 - ResponseMetadata: Response metadata with HTTPStatusCode and HTTPHeaders
 
         Raises:
+            NoSuchKeyError: If the source object does not exist
             PresignError: If required parameters are missing or request fails
 
         Reference:
@@ -496,6 +497,7 @@ class AsyncClient(_BaseClient):
                 - ResponseMetadata: Response metadata with HTTPStatusCode and HTTPHeaders
 
         Raises:
+            NoSuchBucketError: If the bucket does not exist
             PresignError: If required parameters are missing or request fails
 
         Reference:

--- a/src/signurlarity/client.py
+++ b/src/signurlarity/client.py
@@ -278,7 +278,7 @@ class Client(_BaseClient):
                 - ResponseMetadata: Response metadata with HTTPStatusCode and HTTPHeaders
 
         Raises:
-            NoSuchBucketError: If bucket does not exist
+            NoSuchKeyError: If the object does not exist
             PresignError: If request signing or execution fails
 
         Reference:
@@ -399,6 +399,7 @@ class Client(_BaseClient):
                 - ResponseMetadata: Response metadata with HTTPStatusCode and HTTPHeaders
 
         Raises:
+            NoSuchKeyError: If the source object does not exist
             PresignError: If required parameters are missing or request fails
 
         Reference:
@@ -481,6 +482,7 @@ class Client(_BaseClient):
                 - ResponseMetadata: Response metadata with HTTPStatusCode and HTTPHeaders
 
         Raises:
+            NoSuchBucketError: If the bucket does not exist
             PresignError: If required parameters are missing or request fails
 
         Reference:

--- a/src/signurlarity/exceptions.py
+++ b/src/signurlarity/exceptions.py
@@ -126,6 +126,31 @@ class NoSuchBucketError(SignurlarityError):
     pass
 
 
+class NoSuchKeyError(SignurlarityError):
+    """Raised when an S3 object (key) does not exist.
+
+    This exception is raised during object operations when the requested
+    key cannot be found in the bucket. For copy operations it indicates
+    that the source object does not exist.
+
+    Corresponds to an HTTP 404 status code on object-level requests.
+
+    Note:
+        HEAD requests return no response body, so the server cannot always
+        distinguish a missing object from a missing bucket. This exception
+        reflects the most common cause (a missing key); a genuinely missing
+        bucket may also surface as a 404. Use NoSuchBucketError to catch the
+        bucket-missing case explicitly where it can be distinguished.
+
+    Example:
+        >>> client.head_object(Bucket="mybucket", Key="missing.txt")
+        NoSuchKeyError: Object 'missing.txt' in bucket 'mybucket' does not exist or is not accessible
+
+    """
+
+    pass
+
+
 class BucketAlreadyExistsError(SignurlarityError):
     """Raised when trying to create a bucket that already exists.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -269,6 +269,25 @@ def test_put_object_missing_key(s3_clients):
         light_client.put_object(Bucket=BUCKET_NAME, Key="", Body=b"data")
 
 
+# SeaweedFS accepts a PUT to a missing bucket (auto-creates it) instead of
+# returning 404, so it never raises NoSuchBucketError.
+@pytest.mark.parametrize(
+    "s3_clients",
+    [
+        "minio_server",
+        "moto_server",
+        "rustfs_server",
+        pytest.param(
+            "seaweedfs_server",
+            marks=pytest.mark.xfail(
+                reason="SeaweedFS auto-creates the bucket on PUT instead of "
+                "returning 404 NoSuchBucket",
+                strict=True,
+            ),
+        ),
+    ],
+    indirect=True,
+)
 def test_put_object_bucket_not_found(s3_clients):
     """Test that put_object raises NoSuchBucketError for a missing bucket."""
     from signurlarity.exceptions import NoSuchBucketError
@@ -402,6 +421,25 @@ def test_copy_object_missing_copy_source(s3_clients):
         light_client.copy_object(Bucket=BUCKET_NAME, Key="dst.txt", CopySource="")
 
 
+# SeaweedFS returns 400 InvalidArgument when the copy source object cannot be
+# resolved, rather than the 404 NoSuchKey returned by AWS/moto/minio/rustfs.
+@pytest.mark.parametrize(
+    "s3_clients",
+    [
+        "minio_server",
+        "moto_server",
+        "rustfs_server",
+        pytest.param(
+            "seaweedfs_server",
+            marks=pytest.mark.xfail(
+                reason="SeaweedFS returns 400 InvalidArgument for a missing copy "
+                "source instead of 404 NoSuchKey",
+                strict=True,
+            ),
+        ),
+    ],
+    indirect=True,
+)
 def test_copy_object_source_not_found(s3_clients):
     """Test that copy_object raises NoSuchKeyError when the source is missing."""
     from signurlarity.exceptions import NoSuchKeyError

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -109,11 +109,11 @@ def test_head_object_special_chars(s3_clients, key):
 
 
 def test_head_object_not_found(s3_clients):
-    """Test that head_object raises PresignError for non-existent object."""
+    """Test that head_object raises NoSuchKeyError for non-existent object."""
     _boto_client, light_client = s3_clients
-    from signurlarity.exceptions import PresignError
+    from signurlarity.exceptions import NoSuchKeyError
 
-    with pytest.raises(PresignError):
+    with pytest.raises(NoSuchKeyError):
         light_client.head_object(Bucket=BUCKET_NAME, Key="nonexistent_key.txt")
 
 
@@ -269,6 +269,15 @@ def test_put_object_missing_key(s3_clients):
         light_client.put_object(Bucket=BUCKET_NAME, Key="", Body=b"data")
 
 
+def test_put_object_bucket_not_found(s3_clients):
+    """Test that put_object raises NoSuchBucketError for a missing bucket."""
+    from signurlarity.exceptions import NoSuchBucketError
+
+    _boto_client, light_client = s3_clients
+    with pytest.raises(NoSuchBucketError):
+        light_client.put_object(Bucket=MISSING_BUCKET_NAME, Key="key.txt", Body=b"data")
+
+
 def test_list_objects_empty(s3_clients):
     """Test list_objects on a bucket with no matching prefix."""
     _boto_client, light_client = s3_clients
@@ -391,6 +400,19 @@ def test_copy_object_missing_copy_source(s3_clients):
     _boto_client, light_client = s3_clients
     with pytest.raises(PresignError):
         light_client.copy_object(Bucket=BUCKET_NAME, Key="dst.txt", CopySource="")
+
+
+def test_copy_object_source_not_found(s3_clients):
+    """Test that copy_object raises NoSuchKeyError when the source is missing."""
+    from signurlarity.exceptions import NoSuchKeyError
+
+    _boto_client, light_client = s3_clients
+    with pytest.raises(NoSuchKeyError):
+        light_client.copy_object(
+            Bucket=BUCKET_NAME,
+            Key="copy-dst-missing-src.txt",
+            CopySource=f"{BUCKET_NAME}/nonexistent-source-key.txt",
+        )
 
 
 def test_upload_file(s3_clients, tmp_path):

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -291,6 +291,25 @@ async def test_put_object_missing_key_aio(s3_clients_aio):
         await async_light_client.put_object(Bucket=BUCKET_NAME, Key="", Body=b"data")
 
 
+# SeaweedFS accepts a PUT to a missing bucket (auto-creates it) instead of
+# returning 404, so it never raises NoSuchBucketError.
+@pytest.mark.parametrize(
+    "s3_clients_aio",
+    [
+        "minio_server",
+        "moto_server",
+        "rustfs_server",
+        pytest.param(
+            "seaweedfs_server",
+            marks=pytest.mark.xfail(
+                reason="SeaweedFS auto-creates the bucket on PUT instead of "
+                "returning 404 NoSuchBucket",
+                strict=True,
+            ),
+        ),
+    ],
+    indirect=True,
+)
 @pytest.mark.asyncio
 async def test_put_object_bucket_not_found_aio(s3_clients_aio):
     """Test that put_object raises NoSuchBucketError for a missing bucket (async)."""
@@ -440,6 +459,25 @@ async def test_copy_object_missing_copy_source_aio(s3_clients_aio):
         )
 
 
+# SeaweedFS returns 400 InvalidArgument when the copy source object cannot be
+# resolved, rather than the 404 NoSuchKey returned by AWS/moto/minio/rustfs.
+@pytest.mark.parametrize(
+    "s3_clients_aio",
+    [
+        "minio_server",
+        "moto_server",
+        "rustfs_server",
+        pytest.param(
+            "seaweedfs_server",
+            marks=pytest.mark.xfail(
+                reason="SeaweedFS returns 400 InvalidArgument for a missing copy "
+                "source instead of 404 NoSuchKey",
+                strict=True,
+            ),
+        ),
+    ],
+    indirect=True,
+)
 @pytest.mark.asyncio
 async def test_copy_object_source_not_found_aio(s3_clients_aio):
     """Test that copy_object raises NoSuchKeyError when the source is missing (async)."""

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -128,11 +128,11 @@ async def test_head_object_special_chars_aio(s3_clients_aio, key):
 
 @pytest.mark.asyncio
 async def test_head_object_not_found_aio(s3_clients_aio):
-    """Test that head_object raises PresignError for non-existent object."""
+    """Test that head_object raises NoSuchKeyError for non-existent object."""
     _boto_client, async_light_client = s3_clients_aio
-    from signurlarity.exceptions import PresignError
+    from signurlarity.exceptions import NoSuchKeyError
 
-    with pytest.raises(PresignError):
+    with pytest.raises(NoSuchKeyError):
         await async_light_client.head_object(
             Bucket=BUCKET_NAME, Key="nonexistent_key.txt"
         )
@@ -292,6 +292,18 @@ async def test_put_object_missing_key_aio(s3_clients_aio):
 
 
 @pytest.mark.asyncio
+async def test_put_object_bucket_not_found_aio(s3_clients_aio):
+    """Test that put_object raises NoSuchBucketError for a missing bucket (async)."""
+    from signurlarity.exceptions import NoSuchBucketError
+
+    _boto_client, async_light_client = s3_clients_aio
+    with pytest.raises(NoSuchBucketError):
+        await async_light_client.put_object(
+            Bucket=MISSING_BUCKET_NAME, Key="key.txt", Body=b"data"
+        )
+
+
+@pytest.mark.asyncio
 async def test_list_objects_empty_aio(s3_clients_aio):
     """Test list_objects on a bucket with no matching prefix (async)."""
     _boto_client, async_light_client = s3_clients_aio
@@ -425,6 +437,20 @@ async def test_copy_object_missing_copy_source_aio(s3_clients_aio):
     with pytest.raises(PresignError):
         await async_light_client.copy_object(
             Bucket=BUCKET_NAME, Key="dst.txt", CopySource=""
+        )
+
+
+@pytest.mark.asyncio
+async def test_copy_object_source_not_found_aio(s3_clients_aio):
+    """Test that copy_object raises NoSuchKeyError when the source is missing (async)."""
+    from signurlarity.exceptions import NoSuchKeyError
+
+    _boto_client, async_light_client = s3_clients_aio
+    with pytest.raises(NoSuchKeyError):
+        await async_light_client.copy_object(
+            Bucket=BUCKET_NAME,
+            Key="copy-dst-missing-src.txt",
+            CopySource=f"{BUCKET_NAME}/nonexistent-source-key.txt",
         )
 
 


### PR DESCRIPTION
`head_object` and `copy_object` previously raised the generic `PresignError` on a 404, while bucket-level operations raised `NoSuchBucketError`. Add a `NoSuchKeyError` exception and raise it for missing objects on `head_object` and `copy_object`. `put_object` now raises `NoSuchBucketError` on 404, since a PUT creates the key and a 404 can only mean the bucket is missing.

Closes #41