### PR TITLE
fix: percent-encode the x-amz-copy-source header value

### DIFF
--- a/src/signurlarity/_base.py
+++ b/src/signurlarity/_base.py
@@ -442,7 +442,19 @@ class _BaseClient:
             copy_source_str = CopySource
 
         base_url, path, headers = self._build_request_url(Bucket, Key)
-        headers["x-amz-copy-source"] = copy_source_str
+        # The x-amz-copy-source value must be URL-encoded (AWS CopyObject spec).
+        # Encode the "bucket/key" path while preserving an optional
+        # "?versionId=..." suffix, mirroring botocore's _quote_source_header.
+        version_marker = "?versionId="
+        marker_idx = copy_source_str.find(version_marker)
+        if marker_idx == -1:
+            source_path, version_suffix = copy_source_str, ""
+        else:
+            source_path = copy_source_str[:marker_idx]
+            version_suffix = copy_source_str[marker_idx:]
+        headers["x-amz-copy-source"] = (
+            self._presigner._uri_encode_path(source_path) + version_suffix
+        )
 
         if "MetadataDirective" in kwargs:
             headers["x-amz-metadata-directive"] = kwargs["MetadataDirective"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -373,6 +373,45 @@ def test_copy_object_dict_source(s3_clients):
     boto_client.head_object(Bucket=BUCKET_NAME, Key=dst_key)
 
 
+@pytest.mark.parametrize(
+    "src_key",
+    [
+        "copy source with space.txt",
+        "plus+source.txt",
+        "question?source.txt",
+        "hash#source.txt",
+        "percent%source.txt",
+    ],
+)
+def test_copy_object_special_chars_source(s3_clients, src_key):
+    """copy_object must percent-encode the x-amz-copy-source header value.
+
+    The AWS CopyObject spec requires the copy source ("bucket/key") to be
+    URL-encoded. Without encoding, source keys containing characters such as
+    spaces, '+', '?', '#' or '%' are mis-parsed by the server (for example
+    '?' is read as the start of the '?versionId=' query), so the copy either
+    fails or silently targets the wrong object.
+    """
+    boto_client, light_client = s3_clients
+
+    file_content = f"copy-source payload for {src_key}".encode()
+    slug = "".join(c if c.isalnum() else "-" for c in src_key)
+    dst_key = f"copy-special-dst-{slug}.txt"
+
+    boto_client.put_object(Body=file_content, Bucket=BUCKET_NAME, Key=src_key)
+    # Sanity: the source key is legal and present on the backend.
+    boto_client.head_object(Bucket=BUCKET_NAME, Key=src_key)
+
+    light_client.copy_object(
+        Bucket=BUCKET_NAME,
+        Key=dst_key,
+        CopySource=f"{BUCKET_NAME}/{src_key}",
+    )
+
+    got = boto_client.get_object(Bucket=BUCKET_NAME, Key=dst_key)["Body"].read()
+    assert got == file_content
+
+
 def test_copy_object_missing_bucket(s3_clients):
     """Test that copy_object raises PresignError when Bucket is missing."""
     from signurlarity.exceptions import PresignError

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -405,6 +405,47 @@ async def test_copy_object_dict_source_aio(s3_clients_aio):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "src_key",
+    [
+        "copy source with space.txt",
+        "plus+source.txt",
+        "question?source.txt",
+        "hash#source.txt",
+        "percent%source.txt",
+    ],
+)
+async def test_copy_object_special_chars_source_aio(s3_clients_aio, src_key):
+    """copy_object must percent-encode the x-amz-copy-source header value (async).
+
+    The AWS CopyObject spec requires the copy source ("bucket/key") to be
+    URL-encoded. Without encoding, source keys containing characters such as
+    spaces, '+', '?', '#' or '%' are mis-parsed by the server (for example
+    '?' is read as the start of the '?versionId=' query), so the copy either
+    fails or silently targets the wrong object.
+    """
+    boto_client, async_light_client = s3_clients_aio
+
+    file_content = f"copy-source payload for {src_key}".encode()
+    slug = "".join(c if c.isalnum() else "-" for c in src_key)
+    dst_key = f"copy-special-dst-{slug}.txt"
+
+    await boto_client.put_object(Body=file_content, Bucket=BUCKET_NAME, Key=src_key)
+    # Sanity: the source key is legal and present on the backend.
+    await boto_client.head_object(Bucket=BUCKET_NAME, Key=src_key)
+
+    await async_light_client.copy_object(
+        Bucket=BUCKET_NAME,
+        Key=dst_key,
+        CopySource=f"{BUCKET_NAME}/{src_key}",
+    )
+
+    obj = await boto_client.get_object(Bucket=BUCKET_NAME, Key=dst_key)
+    got = await obj["Body"].read()
+    assert got == file_content
+
+
+@pytest.mark.asyncio
 async def test_copy_object_missing_bucket_aio(s3_clients_aio):
     """Test that copy_object raises PresignError when Bucket is missing (async)."""
     from signurlarity.exceptions import PresignError


### PR DESCRIPTION
The [AWS CopyObject spec requires the copy source ("bucket/key") to be URL-encoded](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html), but signurlarity sent the value verbatim. Source keys containing characters such as '?' or '#' were therefore mis-parsed by the server (`?` is read as the start of the `?versionId=` query), causing the copy to 404 or silently target the wrong object.

Encode the bucket/key path with the existing AWS URI encoder while preserving an optional `?versionId=...` suffix, mirroring botocore's `_quote_source_header`.