### PR TITLE
test: drive per-backend skip/xfail via pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
   "moto: tests that only run against the moto server backend",
+  "backend_only: restrict a test to the named S3 backend server fixture(s)",
+  "xfail_backend: strict xfail a test on the named S3 backend server fixture(s)",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ where = ["src"]
 pythonpath = ["src"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+  "moto: tests that only run against the moto server backend",
+]
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ pythonpath = ["src"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
-  "moto: tests that only run against the moto server backend",
   "backend_only: restrict a test to the named S3 backend server fixture(s)",
   "xfail_backend: strict xfail a test on the named S3 backend server fixture(s)",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ import random
 import signal
 import subprocess
 import time
+import urllib.error
+import urllib.request
 from tempfile import TemporaryDirectory
 
 import boto3
@@ -145,60 +147,56 @@ def minio_server():
     subprocess.run(cmd, check=True)  # noqa: S603
 
 
+def _wait_for_seaweedfs_writable(
+    master: str = "localhost:9333", timeout: float = 120, poll_interval: float = 1.0
+) -> None:
+    """Block until the SeaweedFS master can assign a writable volume.
+
+    SeaweedFS creates volumes lazily, so the S3 gateway rejects the first writes
+    until a volume has been grown. A successful ``/dir/assign`` (one that returns
+    a ``fid``) both triggers and confirms volume readiness -- the same operation
+    ``weed upload`` performs internally, but as a single cheap HTTP call with no
+    dependency on the ``weed`` CLI or its output format.
+    """
+    url = f"http://{master}/dir/assign"
+    deadline = time.monotonic() + timeout
+    last_status = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as response:  # noqa: S310
+                payload = json.load(response)
+        except urllib.error.HTTPError as exc:
+            # Assignment errors (e.g. "No free volumes left!") arrive as non-2xx.
+            try:
+                payload = json.load(exc)
+            except ValueError:
+                payload = {"error": f"HTTP {exc.code}"}
+        except (urllib.error.URLError, OSError) as exc:
+            # Master not accepting connections yet.
+            last_status = exc
+            time.sleep(poll_interval)
+            continue
+
+        if payload.get("fid"):
+            return
+        last_status = payload.get("error", payload)
+        time.sleep(poll_interval)
+
+    raise RuntimeError(
+        f"SeaweedFS master at {master} did not provide a writable volume "
+        f"within {timeout:.0f}s (last response: {last_status})"
+    )
+
+
 @pytest.fixture(scope="module")
 def seaweedfs_server():
     """Run a SeaweedFS server with S3 API enabled.
 
-    Because it creates volumes on the fly, we have to upload a file
-    and wait for the initialization to be over, otherwise all the tests
-    fail.
+    Because it creates volumes on the fly, we wait until the master can assign a
+    writable volume before yielding, otherwise the first writes fail.
     """
     AWS_ACCESS_KEY_ID = "admin"
     AWS_SECRET_ACCESS_KEY = "key"  # noqa: S105
-
-    def check_volume_status(max_retries=10, retry_delay=5):
-        cmd = ["weed", "shell"]
-        # Use echo to send the command to weed shell
-        input_cmd = "cluster.status\n"
-
-        for attempt in range(1, max_retries + 1):
-            try:
-                process = subprocess.Popen(  # noqa: S603
-                    cmd,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                )
-                stdout, _stderr = process.communicate(input=input_cmd, timeout=15)
-
-                # Check if "7 volume" is in the output
-                if "7 volume" in stdout:
-                    print("Found '7 volume' in output!")
-                    return
-
-                print(
-                    f"'7 volume' not found (attempt {attempt}/{max_retries}), "
-                    f"retrying in {retry_delay} seconds..."
-                )
-            except subprocess.TimeoutExpired:
-                process.kill()
-                stdout, _stderr = process.communicate()
-                print(
-                    f"weed shell timed out (attempt {attempt}/{max_retries}), "
-                    f"retrying in {retry_delay} seconds..."
-                )
-            except Exception as exc:
-                print(
-                    f"Error checking volume status (attempt {attempt}/{max_retries}): {exc}"
-                )
-
-            if attempt < max_retries:
-                time.sleep(retry_delay)
-
-        raise RuntimeError(
-            f"SeaweedFS did not report '7 volume' after {max_retries} attempts"
-        )
 
     with TemporaryDirectory() as tmp_dir:
         os.mkdir(f"{tmp_dir}/seaweedfs")
@@ -241,34 +239,8 @@ def seaweedfs_server():
 
                 pid = process.pid
                 print(f"Process PID: {pid} Working Directory {tmp_dir}")
-                upload_cmd = [
-                    "weed",
-                    "upload",
-                    "-master",
-                    "localhost:9333",
-                    f"{tmp_dir}/seaweedfs.log",
-                ]
-                max_retries = 10
-                retry_delay = 5
 
-                for attempt in range(1, max_retries + 1):
-                    try:
-                        subprocess.run(  # noqa: S603
-                            upload_cmd, check=True, capture_output=True, text=True
-                        )
-                        print("Upload successful!")
-                        break
-                    except subprocess.CalledProcessError as e:
-                        if attempt >= max_retries:
-                            raise RuntimeError(
-                                f"Upload failed after {max_retries} attempts: {e.stderr}"
-                            ) from e
-                        print(
-                            f"Upload failed (attempt {attempt}/{max_retries}), "
-                            f"retrying in {retry_delay} seconds... (Error: {e.stderr})"
-                        )
-                        time.sleep(retry_delay)
-                check_volume_status()
+                _wait_for_seaweedfs_writable()
 
                 yield {
                     "endpoint_url": "http://localhost:8333",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,9 @@ OTHER_BUCKET_NAME = "other-bucket"
 MISSING_BUCKET_NAME = "missing-bucket"
 INVALID_BUCKET_NAME = ".."
 
+# Server backend fixtures the shared client fixtures fan out across.
+S3_BACKENDS = ("minio_server", "moto_server", "rustfs_server", "seaweedfs_server")
+
 CHECKSUM_ALGORITHM = "sha256"
 
 rng = random.Random(1234)  # noqa: S311
@@ -296,7 +299,7 @@ def seaweedfs_server():
 # Synchronous client fixtures
 @pytest.fixture(
     scope="function",
-    params=["minio_server", "moto_server", "rustfs_server", "seaweedfs_server"],
+    params=list(S3_BACKENDS),
 )
 def s3_clients(request):
     """S3 clients for synchronous tests with multiple server backends.
@@ -323,7 +326,7 @@ def s3_clients(request):
 # Asynchronous client fixtures
 @pytest.fixture(
     scope="function",
-    params=["minio_server", "moto_server", "rustfs_server", "seaweedfs_server"],
+    params=list(S3_BACKENDS),
 )
 async def s3_clients_aio(request):
     """S3 clients for asynchronous tests with multiple server backends.
@@ -352,3 +355,49 @@ async def s3_clients_aio(request):
 
         yield boto_client, async_light_client
         await async_light_client.close()
+
+
+def _active_backend(request):
+    """Return the backend server fixture name for the current parametrization.
+
+    ``None`` if the test is not fanned out across the S3 backends.
+    """
+    callspec = getattr(request.node, "callspec", None)
+    if callspec is None:
+        return None
+    for value in callspec.params.values():
+        if value in S3_BACKENDS:
+            return value
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _apply_backend_constraints(request):
+    """Apply per-backend skip/xfail declared via markers.
+
+    The shared ``s3_clients`` / ``s3_clients_aio`` fixtures fan every test out
+    across all server backends. A few behaviours differ per backend, so tests
+    declare the difference with a marker instead of re-parametrizing the fixture
+    (which pytest forbids when the fixture already defines ``params``):
+
+      * ``@pytest.mark.backend_only("moto_server")`` -- skip every other backend.
+      * ``@pytest.mark.xfail_backend("seaweedfs_server", reason=...)`` -- strict
+        xfail on the named backend(s).
+
+    Being autouse, this runs before ``s3_clients`` during setup, so a skip avoids
+    starting an unused server and an xfail marker lands before the call phase
+    evaluates it. Works for sync and async tests alike.
+    """
+    backend = _active_backend(request)
+    if backend is None:
+        return
+
+    only = request.node.get_closest_marker("backend_only")
+    if only and backend not in only.args:
+        pytest.skip(f"only runs against: {', '.join(only.args)}")
+
+    for marker in request.node.iter_markers("xfail_backend"):
+        if backend in marker.args:
+            request.node.add_marker(
+                pytest.mark.xfail(reason=marker.kwargs.get("reason"), strict=True)
+            )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -468,7 +468,6 @@ def test_upload_file_with_extra_args(s3_clients, tmp_path):
 
 
 # Only Moto exposes the correct ACL api
-@pytest.mark.moto
 @pytest.mark.backend_only("moto_server")
 def test_upload_file_with_acl_extra_args(s3_clients, tmp_path):
     """Test that upload_file applies ACL from ExtraArgs (moto only)."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -269,24 +269,10 @@ def test_put_object_missing_key(s3_clients):
         light_client.put_object(Bucket=BUCKET_NAME, Key="", Body=b"data")
 
 
-# SeaweedFS accepts a PUT to a missing bucket (auto-creates it) instead of
-# returning 404, so it never raises NoSuchBucketError.
-@pytest.mark.parametrize(
-    "s3_clients",
-    [
-        "minio_server",
-        "moto_server",
-        "rustfs_server",
-        pytest.param(
-            "seaweedfs_server",
-            marks=pytest.mark.xfail(
-                reason="SeaweedFS auto-creates the bucket on PUT instead of "
-                "returning 404 NoSuchBucket",
-                strict=True,
-            ),
-        ),
-    ],
-    indirect=True,
+@pytest.mark.xfail_backend(
+    "seaweedfs_server",
+    reason="SeaweedFS auto-creates the bucket on PUT instead of "
+    "returning 404 NoSuchBucket",
 )
 def test_put_object_bucket_not_found(s3_clients):
     """Test that put_object raises NoSuchBucketError for a missing bucket."""
@@ -421,24 +407,10 @@ def test_copy_object_missing_copy_source(s3_clients):
         light_client.copy_object(Bucket=BUCKET_NAME, Key="dst.txt", CopySource="")
 
 
-# SeaweedFS returns 400 InvalidArgument when the copy source object cannot be
-# resolved, rather than the 404 NoSuchKey returned by AWS/moto/minio/rustfs.
-@pytest.mark.parametrize(
-    "s3_clients",
-    [
-        "minio_server",
-        "moto_server",
-        "rustfs_server",
-        pytest.param(
-            "seaweedfs_server",
-            marks=pytest.mark.xfail(
-                reason="SeaweedFS returns 400 InvalidArgument for a missing copy "
-                "source instead of 404 NoSuchKey",
-                strict=True,
-            ),
-        ),
-    ],
-    indirect=True,
+@pytest.mark.xfail_backend(
+    "seaweedfs_server",
+    reason="SeaweedFS returns 400 InvalidArgument for a missing copy "
+    "source instead of 404 NoSuchKey",
 )
 def test_copy_object_source_not_found(s3_clients):
     """Test that copy_object raises NoSuchKeyError when the source is missing."""
@@ -496,11 +468,8 @@ def test_upload_file_with_extra_args(s3_clients, tmp_path):
 
 
 # Only Moto exposes the correct ACL api
-@pytest.mark.parametrize(
-    "s3_clients",
-    [pytest.param("moto_server", marks=pytest.mark.moto)],
-    indirect=True,
-)
+@pytest.mark.moto
+@pytest.mark.backend_only("moto_server")
 def test_upload_file_with_acl_extra_args(s3_clients, tmp_path):
     """Test that upload_file applies ACL from ExtraArgs (moto only)."""
     boto_client, light_client = s3_clients

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -508,7 +508,6 @@ async def test_upload_file_with_extra_args_aio(s3_clients_aio, tmp_path):
     assert head["ContentLength"] == len(content)
 
 
-@pytest.mark.moto
 @pytest.mark.backend_only("moto_server")
 @pytest.mark.asyncio
 async def test_upload_file_with_acl_extra_args_aio(s3_clients_aio, tmp_path):

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -291,24 +291,10 @@ async def test_put_object_missing_key_aio(s3_clients_aio):
         await async_light_client.put_object(Bucket=BUCKET_NAME, Key="", Body=b"data")
 
 
-# SeaweedFS accepts a PUT to a missing bucket (auto-creates it) instead of
-# returning 404, so it never raises NoSuchBucketError.
-@pytest.mark.parametrize(
-    "s3_clients_aio",
-    [
-        "minio_server",
-        "moto_server",
-        "rustfs_server",
-        pytest.param(
-            "seaweedfs_server",
-            marks=pytest.mark.xfail(
-                reason="SeaweedFS auto-creates the bucket on PUT instead of "
-                "returning 404 NoSuchBucket",
-                strict=True,
-            ),
-        ),
-    ],
-    indirect=True,
+@pytest.mark.xfail_backend(
+    "seaweedfs_server",
+    reason="SeaweedFS auto-creates the bucket on PUT instead of "
+    "returning 404 NoSuchBucket",
 )
 @pytest.mark.asyncio
 async def test_put_object_bucket_not_found_aio(s3_clients_aio):
@@ -459,24 +445,10 @@ async def test_copy_object_missing_copy_source_aio(s3_clients_aio):
         )
 
 
-# SeaweedFS returns 400 InvalidArgument when the copy source object cannot be
-# resolved, rather than the 404 NoSuchKey returned by AWS/moto/minio/rustfs.
-@pytest.mark.parametrize(
-    "s3_clients_aio",
-    [
-        "minio_server",
-        "moto_server",
-        "rustfs_server",
-        pytest.param(
-            "seaweedfs_server",
-            marks=pytest.mark.xfail(
-                reason="SeaweedFS returns 400 InvalidArgument for a missing copy "
-                "source instead of 404 NoSuchKey",
-                strict=True,
-            ),
-        ),
-    ],
-    indirect=True,
+@pytest.mark.xfail_backend(
+    "seaweedfs_server",
+    reason="SeaweedFS returns 400 InvalidArgument for a missing copy "
+    "source instead of 404 NoSuchKey",
 )
 @pytest.mark.asyncio
 async def test_copy_object_source_not_found_aio(s3_clients_aio):
@@ -536,12 +508,9 @@ async def test_upload_file_with_extra_args_aio(s3_clients_aio, tmp_path):
     assert head["ContentLength"] == len(content)
 
 
+@pytest.mark.moto
+@pytest.mark.backend_only("moto_server")
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "s3_clients_aio",
-    [pytest.param("moto_server", marks=pytest.mark.moto)],
-    indirect=True,
-)
 async def test_upload_file_with_acl_extra_args_aio(s3_clients_aio, tmp_path):
     """Test that upload_file applies ACL from ExtraArgs (moto only)."""
     boto_client, async_light_client = s3_clients_aio


### PR DESCRIPTION
Fixes these warnings:

```python
tests/test_client.py:441
  /Users/cburr/Development/signurlarity/tests/test_client.py:441: PytestUnknownMarkWarning: Unknown pytest.mark.moto - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    [pytest.param("moto_server", marks=pytest.mark.moto)],

tests/test_client_aio.py:478
  /Users/cburr/Development/signurlarity/tests/test_client_aio.py:478: PytestUnknownMarkWarning: Unknown pytest.mark.moto - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    [pytest.param("moto_server", marks=pytest.mark.moto)],

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```