### PR TITLE
feat: add renovate custom regex to manage rustfs image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
   "enabledManagers": [
     "pip_requirements",
     "pep621",
-    "github-actions"
+    "github-actions",
+    "custom.regex"
   ],
   "python": {
     "rangeStrategy": "auto"
@@ -63,6 +64,30 @@
       "matchPackagePatterns": ["pytest.*", "moto", "aiobotocore", "botocore"],
       "groupName": "Testing dependencies",
       "labels": ["dependencies", "testing"]
+    },
+    {
+      "description": "rustfs w/o -glibc",
+      "matchDepNames": ["rustfs/rustfs"],
+      "matchCurrentVersion": "/\\d+(\\.\\d+(\\.\\d+(-\\w+\\.\\d+)?)?)?$/",
+      "allowedVersions": "/\\d+(\\.\\d+(\\.\\d+(-\\w+\\.\\d+)?)?)?$/"
+    },
+    {
+      "description": "rustfs w/ -glibc",
+      "matchDepNames": ["rustfs/rustfs"],
+      "matchCurrentVersion": "/\\d+(\\.\\d+(\\.\\d+(-\\w+\\.\\d+)?)?)?(-glibc)$/",
+      "allowedVersions": "/\\d+(\\.\\d+(\\.\\d+(-\\w+\\.\\d+)?)?)?(-glibc)$/"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/tests/conftest\\.py$/"],
+      "matchStrings": [
+        "rustfs/rustfs:(?<currentValue>[\\w.-]+)"
+      ],
+      "depNameTemplate": "rustfs/rustfs",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
     }
   ]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def rustfs_server():
         "9000:9000",
         "-p",
         "9001:9001",
-        "rustfs/rustfs:1.0.0-alpha.82",  # return to latest when https://github.com/rustfs/rustfs/issues/1773 is fixed
+        "rustfs/rustfs:1.0.0-alpha.82",
         "/data",
     ]
     # print(shlex.join(cmd))


### PR DESCRIPTION
See https://github.com/DIRACGrid/signurlarity/issues/38

Rustfs uses `rust-release-channel` versioning, but as `alpha` is not supported by this type of versioning, I had to use `semver`. It might be a good idea to manually bump `rustfs:1.0.0-alpha.82` to a beta version and change `semver` to `rust-release-channel`.

Also, I added 2 rules to ignore `glibc` releases if we are not using them and viceversa.

See also https://github.com/AcquaDiGiorgio/signurlarity/pull/7