### PR TITLE
fix!: migrate from httpx to httpx2

### DIFF
--- a/benchmark_tests/test_benchmark.py
+++ b/benchmark_tests/test_benchmark.py
@@ -320,7 +320,7 @@ def test_create_bucket_perf_sync(rustfs_server, test_results_dir):
     """Compare performance of boto3 vs signurlarity for create_bucket.
 
     This benchmark compares boto3's create_bucket with the signurlarity
-    implementation that uses httpx with AWS Signature V4.
+    implementation that uses httpx2 with AWS Signature V4.
     """
     py_vers = sys.version_info
     test_dir = test_results_dir / Path("test_create_bucket_perf")
@@ -398,7 +398,7 @@ def test_delete_objects_perf_sync(rustfs_server, test_results_dir):
     """Compare performance of boto3 vs signurlarity for delete_objects.
 
     This benchmark compares boto3's delete_objects with the signurlarity
-    implementation that uses httpx with AWS Signature V4.
+    implementation that uses httpx2 with AWS Signature V4.
     """
     py_vers = sys.version_info
     test_dir = test_results_dir / Path("test_delete_objects_perf")

--- a/benchmark_tests/test_benchmark_cm.py
+++ b/benchmark_tests/test_benchmark_cm.py
@@ -321,7 +321,7 @@ def test_create_bucket_perf_sync_cm(rustfs_server, test_results_dir):
     """Compare performance of boto3 vs signurlarity for create_bucket.
 
     This benchmark compares boto3's create_bucket with the signurlarity
-    implementation that uses httpx with AWS Signature V4.
+    implementation that uses httpx2 with AWS Signature V4.
     """
     py_vers = sys.version_info
     test_dir = test_results_dir / Path("test_create_bucket_perf_sync_cm")
@@ -397,7 +397,7 @@ def test_delete_objects_perf_sync_cm(rustfs_server, test_results_dir):
     """Compare performance of boto3 vs signurlarity for delete_objects.
 
     This benchmark compares boto3's delete_objects with the signurlarity
-    implementation that uses httpx with AWS Signature V4.
+    implementation that uses httpx2 with AWS Signature V4.
     """
     py_vers = sys.version_info
     test_dir = test_results_dir / Path("test_delete_objects_perf_sync_cm")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.11"
 keywords = []
 license = { text = "GPL-3.0-only" }
 dynamic = ["version"]
-dependencies = ["httpx>=0.24.0", "orjson", "cryptography>=41.0.0"]
+dependencies = ["httpx2>=2.0.0", "orjson", "cryptography>=41.0.0"]
 classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -40,7 +40,7 @@ testing = [
   "aiobotocore>=2.15",
   "botocore>=1.35",
   "moto[server]",
-  "httpx",
+  "httpx2",
   "pytest-xdist",
   "ty",
 ]

--- a/src/signurlarity/_base.py
+++ b/src/signurlarity/_base.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode, urlparse
 from xml.etree import ElementTree
 from xml.sax.saxutils import escape as xml_escape
 
-import httpx
+import httpx2
 
 from .exceptions import (
     BucketAlreadyExistsError,
@@ -52,7 +52,7 @@ class _BaseClient:
         )
 
         # Build connection pool limits for subclasses
-        self._limits = httpx._config.DEFAULT_LIMITS
+        self._limits = httpx2._config.DEFAULT_LIMITS
         if httpx_max_connections:
             self._limits.max_connections = httpx_max_connections
 
@@ -240,7 +240,7 @@ class _BaseClient:
         return url, signed_headers
 
     def _parse_head_bucket_response(
-        self, response: httpx.Response, Bucket: str
+        self, response: httpx2.Response, Bucket: str
     ) -> dict[str, Any]:
         """Parse HEAD bucket response, raising on errors."""
         if response.status_code == 404:
@@ -301,7 +301,7 @@ class _BaseClient:
         return url, signed_headers
 
     def _parse_head_object_response(
-        self, response: httpx.Response, Bucket: str, Key: str
+        self, response: httpx2.Response, Bucket: str, Key: str
     ) -> dict[str, Any]:
         """Parse HEAD object response, raising on errors."""
         if response.status_code == 404:
@@ -382,7 +382,7 @@ class _BaseClient:
         return url, signed_headers, body
 
     def _parse_create_bucket_response(
-        self, response: httpx.Response, Bucket: str
+        self, response: httpx2.Response, Bucket: str
     ) -> dict[str, Any]:
         """Parse PUT bucket response, raising on errors."""
         if response.status_code == 409:
@@ -475,7 +475,7 @@ class _BaseClient:
         return url, signed_headers
 
     def _parse_copy_object_response(
-        self, response: httpx.Response, Bucket: str, Key: str
+        self, response: httpx2.Response, Bucket: str, Key: str
     ) -> dict[str, Any]:
         """Parse copy-object response, raising on errors."""
         if response.status_code == 404:
@@ -559,7 +559,7 @@ class _BaseClient:
         return url, signed_headers
 
     def _parse_list_objects_response(
-        self, response: httpx.Response, Bucket: str
+        self, response: httpx2.Response, Bucket: str
     ) -> dict[str, Any]:
         """Parse list-objects response, raising on errors."""
         if response.status_code == 404:
@@ -673,7 +673,7 @@ class _BaseClient:
         return url, signed_headers, body
 
     def _parse_put_object_response(
-        self, response: httpx.Response, Bucket: str, Key: str
+        self, response: httpx2.Response, Bucket: str, Key: str
     ) -> dict[str, Any]:
         """Parse PUT object response, raising on errors."""
         if response.status_code == 404:
@@ -758,7 +758,7 @@ class _BaseClient:
         return url, signed_headers, body
 
     def _parse_delete_objects_response(
-        self, response: httpx.Response, Bucket: str
+        self, response: httpx2.Response, Bucket: str
     ) -> dict[str, Any]:
         """Parse multi-object delete response, raising on errors."""
         if response.status_code == 404:
@@ -855,7 +855,7 @@ class _BaseClient:
 
     def _parse_delete_bucket_response(
         self,
-        response: httpx.Response,
+        response: httpx2.Response,
         Bucket: str,
     ) -> dict[str, Any]:
         """Parse delete bucket response, raising on errors."""

--- a/src/signurlarity/_base.py
+++ b/src/signurlarity/_base.py
@@ -34,7 +34,7 @@ class _BaseClient:
         endpoint_url: str,
         aws_access_key_id: str,
         aws_secret_access_key: str,
-        httpx_max_connections: Optional[int] = None,
+        max_connections: Optional[int] = None,
     ):
         self.endpoint_url = endpoint_url
         self.aws_access_key_id = aws_access_key_id
@@ -53,8 +53,8 @@ class _BaseClient:
 
         # Build connection pool limits for subclasses
         self._limits = httpx2._config.DEFAULT_LIMITS
-        if httpx_max_connections:
-            self._limits.max_connections = httpx_max_connections
+        if max_connections:
+            self._limits.max_connections = max_connections
 
     def _extract_region(self, endpoint_url: str) -> str:
         """Extract AWS region from endpoint URL.

--- a/src/signurlarity/aio/client.py
+++ b/src/signurlarity/aio/client.py
@@ -6,7 +6,7 @@ import asyncio
 from pathlib import Path
 from typing import Any
 
-import httpx
+import httpx2
 
 from .._base import _BaseClient
 from ..exceptions import PresignError
@@ -17,7 +17,7 @@ class AsyncClient(_BaseClient):
 
     This is a lightweight, boto3-compatible async client that focuses on presigned URL
     generation and basic S3 operations without the boto3 dependency overhead.
-    Uses async connection pooling via httpx for better performance in async applications.
+    Uses async connection pooling via httpx2 for better performance in async applications.
 
     Args:
         endpoint_url: S3 endpoint URL. Examples:
@@ -27,7 +27,7 @@ class AsyncClient(_BaseClient):
         aws_access_key_id: AWS access key ID for authentication
         aws_secret_access_key: AWS secret access key for authentication
         httpx_max_connections: Optional maximum number of connections in the pool.
-                              If not specified, uses httpx default limits.
+                              If not specified, uses httpx2 default limits.
 
     Example:
         >>> # Basic async usage with explicit cleanup
@@ -84,7 +84,7 @@ class AsyncClient(_BaseClient):
         ...     )
 
     Note:
-        This client uses async connection pooling via httpx.AsyncClient() for better
+        This client uses async connection pooling via httpx2.AsyncClient() for better
         performance in async applications. The same HTTP client instance is reused
         across multiple requests, reducing connection overhead and enabling HTTP/2 benefits.
         Always use the async context manager or call await close() to properly clean up
@@ -105,11 +105,11 @@ class AsyncClient(_BaseClient):
             aws_secret_access_key=aws_secret_access_key,
             httpx_max_connections=httpx_max_connections,
         )
-        self._http_client = httpx.AsyncClient(limits=self._limits)
+        self._http_client = httpx2.AsyncClient(limits=self._limits)
 
     async def _execute_request(
         self, method: str, url: str, headers: dict[str, str], body: bytes = b""
-    ) -> httpx.Response:
+    ) -> httpx2.Response:
         """Execute an HTTP request using async connection pooling.
 
         Args:
@@ -119,7 +119,7 @@ class AsyncClient(_BaseClient):
             body: Request body (for PUT/POST)
 
         Returns:
-            httpx.Response object
+            httpx2.Response object
 
         Raises:
             PresignError: If request execution fails
@@ -138,7 +138,7 @@ class AsyncClient(_BaseClient):
                 return await self._http_client.post(url, headers=headers, content=body)
             else:
                 raise PresignError(f"Unsupported HTTP method: {method}")
-        except httpx.HTTPError as e:
+        except httpx2.HTTPError as e:
             raise PresignError(f"Failed to execute {method} request: {str(e)}") from e
         except Exception as e:
             raise PresignError(f"Failed to execute {method} request: {str(e)}") from e

--- a/src/signurlarity/aio/client.py
+++ b/src/signurlarity/aio/client.py
@@ -26,8 +26,8 @@ class AsyncClient(_BaseClient):
                      - Custom S3-compatible services
         aws_access_key_id: AWS access key ID for authentication
         aws_secret_access_key: AWS secret access key for authentication
-        httpx_max_connections: Optional maximum number of connections in the pool.
-                              If not specified, uses httpx2 default limits.
+        max_connections: Optional maximum number of connections in the pool.
+                         If not specified, uses httpx2 default limits.
 
     Example:
         >>> # Basic async usage with explicit cleanup
@@ -97,13 +97,13 @@ class AsyncClient(_BaseClient):
         endpoint_url: str,
         aws_access_key_id: str,
         aws_secret_access_key: str,
-        httpx_max_connections: int | None = None,
+        max_connections: int | None = None,
     ):
         super().__init__(
             endpoint_url=endpoint_url,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
-            httpx_max_connections=httpx_max_connections,
+            max_connections=max_connections,
         )
         self._http_client = httpx2.AsyncClient(limits=self._limits)
 

--- a/src/signurlarity/client.py
+++ b/src/signurlarity/client.py
@@ -24,8 +24,8 @@ class Client(_BaseClient):
                      - Custom S3-compatible services
         aws_access_key_id: AWS access key ID for authentication
         aws_secret_access_key: AWS secret access key for authentication
-        httpx_max_connections: Optional maximum number of connections in the pool.
-                              If not specified, uses httpx2 default limits.
+        max_connections: Optional maximum number of connections in the pool.
+                         If not specified, uses httpx2 default limits.
 
     Example:
         >>> # Basic usage with explicit cleanup
@@ -81,13 +81,13 @@ class Client(_BaseClient):
         endpoint_url: str,
         aws_access_key_id: str,
         aws_secret_access_key: str,
-        httpx_max_connections: int | None = None,
+        max_connections: int | None = None,
     ):
         super().__init__(
             endpoint_url=endpoint_url,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
-            httpx_max_connections=httpx_max_connections,
+            max_connections=max_connections,
         )
         self._http_client = httpx2.Client(limits=self._limits)
 

--- a/src/signurlarity/client.py
+++ b/src/signurlarity/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-import httpx
+import httpx2
 
 from ._base import _BaseClient
 from .exceptions import PresignError
@@ -15,7 +15,7 @@ class Client(_BaseClient):
 
     This is a lightweight, boto3-compatible client that focuses on presigned URL
     generation and basic S3 operations without the boto3 dependency overhead.
-    Uses connection pooling via httpx for better performance.
+    Uses connection pooling via httpx2 for better performance.
 
     Args:
         endpoint_url: S3 endpoint URL. Examples:
@@ -25,7 +25,7 @@ class Client(_BaseClient):
         aws_access_key_id: AWS access key ID for authentication
         aws_secret_access_key: AWS secret access key for authentication
         httpx_max_connections: Optional maximum number of connections in the pool.
-                              If not specified, uses httpx default limits.
+                              If not specified, uses httpx2 default limits.
 
     Example:
         >>> # Basic usage with explicit cleanup
@@ -68,7 +68,7 @@ class Client(_BaseClient):
         ...     )
 
     Note:
-        This client uses connection pooling via httpx.Client() for better
+        This client uses connection pooling via httpx2.Client() for better
         performance. The same HTTP client instance is reused across multiple
         requests, reducing connection overhead and enabling HTTP/2 benefits.
         Always use the context manager or call close() to properly clean up
@@ -89,11 +89,11 @@ class Client(_BaseClient):
             aws_secret_access_key=aws_secret_access_key,
             httpx_max_connections=httpx_max_connections,
         )
-        self._http_client = httpx.Client(limits=self._limits)
+        self._http_client = httpx2.Client(limits=self._limits)
 
     def _execute_request(
         self, method: str, url: str, headers: dict[str, str], body: bytes = b""
-    ) -> httpx.Response:
+    ) -> httpx2.Response:
         """Execute an HTTP request using connection pooling.
 
         Args:
@@ -103,7 +103,7 @@ class Client(_BaseClient):
             body: Request body (for PUT/POST)
 
         Returns:
-            httpx.Response object
+            httpx2.Response object
 
         Raises:
             PresignError: If request execution fails
@@ -122,7 +122,7 @@ class Client(_BaseClient):
                 return self._http_client.post(url, headers=headers, content=body)
             else:
                 raise PresignError(f"Unsupported HTTP method: {method}")
-        except httpx.HTTPError as e:
+        except httpx2.HTTPError as e:
             raise PresignError(f"Failed to execute {method} request: {str(e)}") from e
         except Exception as e:
             raise PresignError(f"Failed to execute {method} request: {str(e)}") from e

--- a/src/signurlarity/presigner.py
+++ b/src/signurlarity/presigner.py
@@ -326,9 +326,9 @@ class S3Presigner:
             ...     headers=headers,
             ...     body=b"",
             ... )
-            >>> # Use signed headers with httpx or requests
-            >>> import httpx
-            >>> response = httpx.head(
+            >>> # Use signed headers with httpx2 or requests
+            >>> import httpx2
+            >>> response = httpx2.head(
             ...     "https://mybucket.s3.us-west-2.amazonaws.com/",
             ...     headers=signed_headers,
             ... )
@@ -342,8 +342,8 @@ class S3Presigner:
             ...     headers=headers,
             ...     body=body,
             ... )
-            >>> import httpx
-            >>> response = httpx.put(
+            >>> import httpx2
+            >>> response = httpx2.put(
             ...     "https://mybucket.s3.us-west-2.amazonaws.com/myfile.txt",
             ...     headers=signed_headers,
             ...     content=body,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@ import logging
 import tempfile
 
 import botocore
-import httpx
+import httpx2
 import pytest
 
 from signurlarity.exceptions import NoSuchBucketError
@@ -145,7 +145,7 @@ def test_head_object_missing_bucket_param(s3_clients):
 def test_generate_presigned_post(s3_clients):
     """Upload files using post presigned URLs.
 
-    Get a pre-signed URL with our client, upload with httpx
+    Get a pre-signed URL with our client, upload with httpx2
     check it exists with boto.
     """
     boto_client, light_client = s3_clients
@@ -170,7 +170,7 @@ def test_generate_presigned_post(s3_clients):
         ExpiresIn=60,
     )
 
-    with httpx.Client() as client:
+    with httpx2.Client() as client:
         r = client.post(
             upload_info["url"],
             data=upload_info["fields"],
@@ -182,8 +182,8 @@ def test_generate_presigned_post(s3_clients):
 
 
 def test_generate_presigned_url(s3_clients, caplog):
-    """Get a pre-signed URL with our client, upload with httpx, check it exists with boto."""
-    caplog.set_level(logging.DEBUG, logger="httpx")
+    """Get a pre-signed URL with our client, upload with httpx2, check it exists with boto."""
+    caplog.set_level(logging.DEBUG, logger="httpx2")
     caplog.set_level(logging.DEBUG, logger="httpcore")
 
     boto_client, light_client = s3_clients
@@ -202,7 +202,7 @@ def test_generate_presigned_url(s3_clients, caplog):
     )
 
     with tempfile.TemporaryFile(mode="w+b") as fh:
-        with httpx.Client() as http_client:
+        with httpx2.Client() as http_client:
             response = http_client.get(presigned_url)
             response.raise_for_status()
             for chunk in response.iter_bytes():

--- a/tests/test_client_aio.py
+++ b/tests/test_client_aio.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import tempfile
 
-import httpx
+import httpx2
 import pytest
 from botocore.errorfactory import ClientError
 
@@ -162,7 +162,7 @@ async def test_head_object_missing_bucket_param_aio(s3_clients_aio):
 async def test_generate_presigned_post_aio(s3_clients_aio):
     """Upload files using post presigned URLs with async client.
 
-    Get a pre-signed URL with our async client, upload with httpx
+    Get a pre-signed URL with our async client, upload with httpx2
     check it exists with boto.
     """
     boto_client, async_light_client = s3_clients_aio
@@ -187,7 +187,7 @@ async def test_generate_presigned_post_aio(s3_clients_aio):
         ExpiresIn=60,
     )
 
-    with httpx.Client() as client:
+    with httpx2.Client() as client:
         r = client.post(
             upload_info["url"],
             data=upload_info["fields"],
@@ -200,8 +200,8 @@ async def test_generate_presigned_post_aio(s3_clients_aio):
 
 @pytest.mark.asyncio
 async def test_generate_presigned_url_aio(s3_clients_aio, caplog):
-    """Get a pre-signed URL with our async client, upload with httpx, check it exists with boto."""
-    caplog.set_level(logging.DEBUG, logger="httpx")
+    """Get a pre-signed URL with our async client, upload with httpx2, check it exists with boto."""
+    caplog.set_level(logging.DEBUG, logger="httpx2")
     caplog.set_level(logging.DEBUG, logger="httpcore")
 
     boto_client, async_light_client = s3_clients_aio
@@ -220,7 +220,7 @@ async def test_generate_presigned_url_aio(s3_clients_aio, caplog):
     )
 
     with tempfile.TemporaryFile(mode="w+b") as fh:
-        with httpx.Client() as http_client:
+        with httpx2.Client() as http_client:
             response = http_client.get(presigned_url)
             response.raise_for_status()
             for chunk in response.iter_bytes():


### PR DESCRIPTION
## Summary
- httpx is dormant; pydantic has taken over maintenance under the `httpx2` name (https://github.com/pydantic/httpx2)
- Swap the `httpx` dependency for `httpx2` and update all imports/usages (`httpx.Client`, `httpx.AsyncClient`, `httpx.Response`, `httpx.HTTPError`, etc.) across `src/`, `tests/`, and `benchmark_tests/`

## Breaking change
- Renamed the `Client`/`AsyncClient` constructor kwarg `httpx_max_connections` to `max_connections`.

Closes #46